### PR TITLE
Deal with package name ambiguity

### DIFF
--- a/addchroot
+++ b/addchroot
@@ -30,7 +30,7 @@ while [ $# -gt 1 ]
 do
   shift
   PKG=$1
-  P=$(ls /var/log/packages/$PKG* |  head -n 1 |
+  P=$(ls /var/log/packages/$PKG* |  head -n1 |
     grep -E "$PKG-[rv]{0,1}[0-9][^-]*-([^-]*-){0,1}($ARCH|noarch)")
   [ -f "$P" ] || { echo "$PKG finds only $P" >&2; exit 1; }
 

--- a/addchroot
+++ b/addchroot
@@ -30,7 +30,7 @@ while [ $# -gt 1 ]
 do
   shift
   PKG=$1
-  P=$(ls /var/log/packages/$PKG* |
+  P=$(ls /var/log/packages/$PKG* |  sed -n '1 p' |
     grep -E "$PKG-[rv]{0,1}[0-9][^-]*-([^-]*-){0,1}($ARCH|noarch)")
   [ -f "$P" ] || { echo "$PKG finds only $P" >&2; exit 1; }
 

--- a/addchroot
+++ b/addchroot
@@ -30,7 +30,7 @@ while [ $# -gt 1 ]
 do
   shift
   PKG=$1
-  P=$(ls /var/log/packages/$PKG* |  sed -n '1 p' |
+  P=$(ls /var/log/packages/$PKG* |  head -n 1 |
     grep -E "$PKG-[rv]{0,1}[0-9][^-]*-([^-]*-){0,1}($ARCH|noarch)")
   [ -f "$P" ] || { echo "$PKG finds only $P" >&2; exit 1; }
 


### PR DESCRIPTION
If multiple packages match $PKG, "ls" will return one per line, causing script to fail. For example: vim and vim-gvim; man-db and man-pages. Use sed to take only the first line from the "ls" stdout. Can always provide full name of package e.g. "vim-gvim" if that's the one desired.